### PR TITLE
피드백 반영 : exception은 도메인 패키지 아래에 둔다

### DIFF
--- a/week3/src/main/java/com/tdd/concert/domain/exception/GlobalExceptionHandler.java
+++ b/week3/src/main/java/com/tdd/concert/domain/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.tdd.concert.exception;
+package com.tdd.concert.domain.exception;
 
 import com.tdd.concert.api.controller.dto.response.ExceptionResponseDto;
 import org.springframework.http.HttpStatus;


### PR DESCRIPTION
4주차 허재코치님 피드백 반영

- exception은 비즈니스 레이어에서 발생하기 때문에 도메인 패키지 아래에 둔다