### PR TITLE
수정중 : 동시성 테스트 케이스 오류

### DIFF
--- a/week3/src/main/java/com/tdd/concert/api/usecase/ReserveSeatUseCase.java
+++ b/week3/src/main/java/com/tdd/concert/api/usecase/ReserveSeatUseCase.java
@@ -11,6 +11,7 @@ import com.tdd.concert.domain.seat.component.SeatManager;
 import com.tdd.concert.domain.seat.model.Seat;
 import com.tdd.concert.domain.user.component.UserManager;
 import com.tdd.concert.domain.user.model.User;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -27,25 +28,25 @@ public class ReserveSeatUseCase {
 
 
   /** 좌석 예약 */
+  @Transactional
   public ReservationResponse reserve(ReservationRequest request) {
     log.info("[ReserveSeatUseCase] 예약 시작");
 
-    // 사용자를 조회한다.
+    // 석1. 사용자를 조회한다.
     User user = userManager.findUserById(request.getUserId());
     if(user == null) {
       throw new RuntimeException("[좌석 예약] 존재하지 않는 사용자입니다.");
     }
     log.info("[ReserveSeatUseCase] 사용자 검증 완료");
 
-    // 콘서트를 조회한다.
+    // 2. 콘서트를 조회한다.
     Concert concert = concertManager.findConcertByConcertId(request.getConcertId());
     if(concert == null) {
       throw new RuntimeException("[좌석 예약] 존재하지  콘서트입니다.");
     }
     log.info("[ReserveSeatUseCase] 콘서트 조회완료");
 
-    /** TODO 만약에 동시에 여러명이 이 좌석을 예약하려고 할 땐??
-     * */
+    // 3. 좌석을 임시배정한다.
     Seat occupiedSeat = seatManager.occupy(request.getSeatNo(),
                                            concert.getConcertId(),
                                            request.getConcertDate(),

--- a/week3/src/main/java/com/tdd/concert/domain/seat/component/SeatManager.java
+++ b/week3/src/main/java/com/tdd/concert/domain/seat/component/SeatManager.java
@@ -22,20 +22,26 @@ public class SeatManager {
   private final SeatReader seatReader;
 
   public Seat findSeatBySeatNoAndConcert(Long seatNo, Long concertId, LocalDate concertDate) {
-    return seatReader.findSeatBySeatNoWithExclusiveLock(seatNo, concertId, concertDate);
+    return seatReader.findSeatBySeatNoAndConcert(seatNo, concertId, concertDate);
   }
 
-  @Transactional
   public Seat occupy(Long seatNo, Long concertId, LocalDate concertDate, User user) {
+    log.info("[SeatManager] 좌석 occupy 메서드 진입");
 
     /** 비관적락으로 Seat 조회 */
     Seat seat = seatReader.findSeatBySeatNoWithExclusiveLock(seatNo, concertId, concertDate);
+    log.info("[SeatManager] 좌석 비관적락으로 조회 완료");
+
 
     /** 좌석 검증처리 */
     seatValidator.validate(seat);
 
+    log.info("[SeatManager] 좌석 검증처리 완료");
+
     /** 좌석의 임시배정만료시각, 임시배정 사용자아이디, 좌석예약상태를 설정 후 저장. */
     seat.tempOccupy(user.getUserId());
+
+    log.info("[SeatManager] 좌석 tempOccupy 완료");
 
     // return seatCoreRepository.save(seat);
     return seat;

--- a/week3/src/main/java/com/tdd/concert/domain/seat/component/SeatValidator.java
+++ b/week3/src/main/java/com/tdd/concert/domain/seat/component/SeatValidator.java
@@ -15,9 +15,8 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class SeatValidator {
 
-  private final SeatCoreRepository seatCoreRepository;
-
   public void validate(Seat seat) {
+    log.info("[SeatValidator] 좌석 validate 메서드 진입");
 
     if(seat.getSeatStatus() == SeatStatus.TEMPORARY_RESERVED) {
       throw new RuntimeException("이미 다른 사용자에게 임시배정된 좌석입니다. 좌석번호 : " + seat.getSeatNo());
@@ -26,6 +25,7 @@ public class SeatValidator {
       throw new RuntimeException("이미 판매완료된 좌석입니다. 좌석번호 : " + seat.getSeatNo());
     }
 
+    log.info("[SeatValidator] 좌석 validate 메서드 끝");
   }
 
 

--- a/week3/src/main/java/com/tdd/concert/domain/seat/model/Seat.java
+++ b/week3/src/main/java/com/tdd/concert/domain/seat/model/Seat.java
@@ -17,6 +17,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 @Entity
 @Table
@@ -25,6 +26,7 @@ import lombok.ToString;
 @Setter
 @NoArgsConstructor
 @Builder
+@Slf4j
 public class Seat {
 
     @Id
@@ -55,9 +57,13 @@ public class Seat {
     private ConcertSchedule concertSchedule;
 
     public void tempOccupy(Long userId) {
+        log.info("[Seat 엔티티 내부] tempOccupy 메서드 진입");
+
         this.setTempReservedUserId(userId);
         this.setTempReservedExpiredAt(LocalDateTime.now().plusMinutes(5));
         this.setSeatStatus(SeatStatus.TEMPORARY_RESERVED);
+
+        log.info("[Seat 엔티티 내부] tempOccupy 메서드 완료");
     }
 
     public void expire() {

--- a/week3/src/main/java/com/tdd/concert/domain/seat/repository/SeatJpaRepository.java
+++ b/week3/src/main/java/com/tdd/concert/domain/seat/repository/SeatJpaRepository.java
@@ -16,6 +16,7 @@ public interface SeatJpaRepository extends JpaRepository<Seat, Long> {
   @Query("SELECT s FROM Seat s WHERE s.seatNo = ?1 AND s.concert.concertId = ?2 AND s.concertSchedule.concertDate = ?3")
   public Seat findSeatBySeatNoAndConcert(Long seatNo, Long concertId, LocalDate concertDate);
 
+  // 동시성 제어를 위한 비관적락
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("select s from Seat s where s.seatNo = ?1 AND s.concert.concertId = ?2 AND s.concertSchedule.concertDate = ?3")
   public Seat findSeatBySeatNoWithExclusiveLock(Long seatNo, Long concertId, LocalDate concertDate);

--- a/week3/src/test/java/com/tdd/concert/api/usecase/ReserveSeatIntegrationTest.java
+++ b/week3/src/test/java/com/tdd/concert/api/usecase/ReserveSeatIntegrationTest.java
@@ -128,7 +128,6 @@ public class ReserveSeatIntegrationTest {
 
 
   @DisplayName("다수의 요청자가 1개의 좌석을 동시에 예약하려고 한다.")
-  @Disabled
   @Test
   void case4() throws InterruptedException {
     // given


### PR DESCRIPTION
좌석 예약 동시성 테스트 케이스에서 테스트가 종료되지 않고 계속 진행되는 현상 발생.

[좌석 예약 프로그램 흐름]
1. ReserveSeatUseCase.java 에서 좌석예약 시작(각 도메인별 Manager 호출)
2. UserManager호출하여 사용자 조회
3. ConcertManager호출하여 콘서트 조회
4. SeatManager 호출하여 좌석 임시배정.

[ 확인 내용]
1. 좌석 테이블에 비관적 락을 걸 때, Join 관계가 있는 Concert, ConcertSchedule에 락이 전파된 것이 원인이라고 판단.
=> 확인 결과 : 비관락 쿼리문에서 Join을 걸지 않고, Seat 테이블만 조회해도 동일하게 테스트가 계속 돌아가는 현상 발생. => 원인 아님

2. SeatManager 내부의 occupy 메서드에서 오류가 있는 것으로 예상 중
=> 확인 결과 : 로그를 찍어보니 seatValidator.validate(seat) 에서 메서드가 더 진행되지 않는 현상이 발생. 그러나 원인 불명.
SeatValidator는 단순 검증을 하는 클래스인데 진행이 되지 않는 것이 이상합니다.

[리뷰 요청 내용]
1. 제 좌석예약 로직상에 교착상태 또는 문제가 있는지 리뷰 부탁드립니다.