### PR TITLE
수정:좌석예약(낙관적락)에 validation 로직 추가하여 중복 예약 방지

### DIFF
--- a/week3/src/main/java/com/tdd/concert/domain/seat_optimistic/component/SeatManagerO.java
+++ b/week3/src/main/java/com/tdd/concert/domain/seat_optimistic/component/SeatManagerO.java
@@ -13,13 +13,17 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class SeatManagerO {
 
-  private final SeatReaderO seatReader;
+  private final SeatReaderO seatReaderO;
+  private final SeatValidatorO seatValidatorO;
 
   public SeatO occupy(Long seatNo, Long concertId, LocalDate concertDate, User user) {
     log.info("[SeatManagerO] occupy 진입");
 
      // 일단은 일반 조회로직으로 설정
-    SeatO occupySeatO = seatReader.findSeatBySeatNoWithOptimisticLock(seatNo, concertId, concertDate);
+    SeatO occupySeatO = seatReaderO.findSeatBySeatNoWithOptimisticLock(seatNo, concertId, concertDate);
+
+    /** 좌석 검증처리 */
+    seatValidatorO.validate(occupySeatO);
 
     occupySeatO.tempOccupy(user.getUserId());
 

--- a/week3/src/main/java/com/tdd/concert/domain/seat_optimistic/component/SeatValidatorO.java
+++ b/week3/src/main/java/com/tdd/concert/domain/seat_optimistic/component/SeatValidatorO.java
@@ -1,0 +1,28 @@
+package com.tdd.concert.domain.seat_optimistic.component;
+
+import com.tdd.concert.domain.seat_optimistic.model.SeatO;
+import com.tdd.concert.domain.seat_optimistic.model.SeatStatusO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SeatValidatorO {
+
+  public void validate(SeatO seatO) {
+    log.info("[SeatValidator] 좌석 validate 메서드 진입");
+
+    if(seatO.getSeatStatusO() == SeatStatusO.TEMPORARY_RESERVED) {
+      throw new RuntimeException("이미 다른 사용자에게 임시배정된 좌석입니다. 좌석번호 : " + seatO.getSeatNo());
+
+    } else if(seatO.getSeatStatusO() == SeatStatusO.SOLDOUT) {
+      throw new RuntimeException("이미 판매완료된 좌석입니다. 좌석번호 : " + seatO.getSeatNo());
+    }
+
+    log.info("[SeatValidator] 좌석 validate 메서드 끝");
+  }
+
+
+}

--- a/week3/src/main/java/com/tdd/concert/domain/seat_optimistic/model/SeatO.java
+++ b/week3/src/main/java/com/tdd/concert/domain/seat_optimistic/model/SeatO.java
@@ -65,6 +65,9 @@ public class SeatO {
     public void tempOccupy(Long userId) {
         log.info("[SeatO 엔티티 내부] tempOccupy 메서드 진입");
 
+        if(this.getSeatStatusO() != SeatStatusO.AVAILABLE) {
+            throw new RuntimeException("예약가능한 좌석이 아닙니다.. 좌석번호 : " + this.getSeatNo() + ", 좌석 상태 : " + this.getSeatStatusO());
+        }
         this.setTempReservedUserId(userId);
         this.setTempReservedExpiredAt(LocalDateTime.now().plusMinutes(5));
         this.setSeatStatusO(SeatStatusO.TEMPORARY_RESERVED);

--- a/week3/src/test/java/com/tdd/concert/api/concurrency/ReservationSeatOptimisticLockTest.java
+++ b/week3/src/test/java/com/tdd/concert/api/concurrency/ReservationSeatOptimisticLockTest.java
@@ -82,7 +82,7 @@ public class ReservationSeatOptimisticLockTest {
             .concertSchedule(concertSchedule)
             .tempReservedExpiredAt(null)
             .tempReservedUserId(null)
-            .version(1L)
+            .version(0L)
             .build()
     );
   }
@@ -145,7 +145,7 @@ public class ReservationSeatOptimisticLockTest {
     assertEquals(threadCount-failCnt.intValue(), successCnt.intValue());
 
     // version은 성공한 횟수만큼 증가
-    assertEquals(successCnt.intValue(), actualSeatO.getVersion());
+    assertEquals(1, actualSeatO.getVersion());
   }
 
 


### PR DESCRIPTION
#60 좌석예약 낙관적락 구현
변경 전 : 낙관적 락으로 좌석 예약 테스트를 할 때, 스레드가 10개가 넘으면 version이 0->3 증가하는 현상이 발생.

원인 : 낙관적 락은 스레드가 동시에 요청할 때, 동시에 읽은 버전정보를 가지고 갱신할 수가 있다. 그래서 상태체크 로직이 필수

변경 후 : 좌석의 상태체크 로직을 추가하였다. 스레드가 많아도 좌석의 version은 0->1로 변경